### PR TITLE
Console color fix

### DIFF
--- a/src/main/java/nl/tudelft/goalkeeper/util/console/Console.java
+++ b/src/main/java/nl/tudelft/goalkeeper/util/console/Console.java
@@ -33,7 +33,7 @@ public final class Console {
      */
     public static void print(String text, ConsoleColor color) {
         if (useColor) {
-            System.out.print(color.getAnsi() + text + ConsoleColor.DEFAULT);
+            System.out.print(color.getAnsi() + text + ConsoleColor.DEFAULT.getAnsi());
         } else {
             System.out.print(text);
         }

--- a/src/main/java/nl/tudelft/goalkeeper/util/console/Console.java
+++ b/src/main/java/nl/tudelft/goalkeeper/util/console/Console.java
@@ -33,7 +33,7 @@ public final class Console {
      */
     public static void print(String text, ConsoleColor color) {
         if (useColor) {
-            System.out.print(color.getAnsi() + text);
+            System.out.print(color.getAnsi() + text + ConsoleColor.DEFAULT);
         } else {
             System.out.print(text);
         }

--- a/src/test/java/nl/tudelft/goalkeeper/ProgramTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/ProgramTest.java
@@ -83,6 +83,7 @@ class ProgramTest {
                 .hasMessage(ExitCode.NO_RULES + "");
         assertThat(out.toString(UTF8)).contains(ConsoleColor.RED.getAnsi()
                 + "[ERROR] No '-rules=...' parameter found."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 
@@ -96,6 +97,7 @@ class ProgramTest {
                 .hasMessage(ExitCode.NO_MAS + "");
         assertThat(out.toString(UTF8)).contains(ConsoleColor.RED.getAnsi()
                 + "[ERROR] No '-mas=...' parameter found."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 
@@ -109,6 +111,7 @@ class ProgramTest {
                 .hasMessage(ExitCode.NO_MAS + "");
         assertThat(out.toString(UTF8)).contains(ConsoleColor.RED.getAnsi()
                 + "[ERROR] File 'true' is not a '.mas2g' file."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 
@@ -122,6 +125,7 @@ class ProgramTest {
                 .hasMessage(ExitCode.NO_MAS + "");
         assertThat(out.toString(UTF8)).contains(ConsoleColor.RED.getAnsi()
                 + "[ERROR] File 'blablabla.mas2g' does not exist."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 
@@ -137,6 +141,7 @@ class ProgramTest {
                 .hasMessage(ExitCode.NO_RULES + "");
         assertThat(out.toString(UTF8)).contains(ConsoleColor.RED.getAnsi()
                 + "[ERROR] An error occured while trying to open file 'true'."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 
@@ -153,6 +158,7 @@ class ProgramTest {
         assertThat(out.toString(UTF8)).contains(ConsoleColor.RED.getAnsi()
                 + "[ERROR] Malformed JSON 'src/test/resources/testfiles/"
                 +  "empty-project-files/mas.mas2g' ruleset found."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 
@@ -168,6 +174,7 @@ class ProgramTest {
                 .hasMessage(ExitCode.SUCCESSFUL + "");
         assertThat(out.toString(UTF8)).contains(ConsoleColor.BLUE.getAnsi()
                 + "Build succeeded with 0 errors and 0 warnings."
+                + ConsoleColor.DEFAULT.getAnsi()
                 + NEWLINE);
     }
 }

--- a/src/test/java/nl/tudelft/goalkeeper/util/console/ConsoleTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/util/console/ConsoleTest.java
@@ -70,7 +70,7 @@ class ConsoleTest {
     void printColorEnabledTest() throws UnsupportedEncodingException {
         Console.setUseColor(true);
         Console.print("hjk", ConsoleColor.PURPLE);
-        assertThat(out.toString(UTF8)).isEqualTo("\u001B[35mhjk");
+        assertThat(out.toString(UTF8)).isEqualTo("\u001B[35mhjk\u001B[0m");
     }
 
     /**
@@ -98,6 +98,6 @@ class ConsoleTest {
     void printlnColorEnabledTest() throws UnsupportedEncodingException {
         Console.setUseColor(true);
         Console.println("das", ConsoleColor.CYAN);
-        assertThat(out.toString(UTF8)).isEqualTo("\u001B[36mdas" + NEWLINE);
+        assertThat(out.toString(UTF8)).isEqualTo("\u001B[36mdas\u001B[0m" + NEWLINE);
     }
 }


### PR DESCRIPTION
Resolves #33

#### Changes:
- `Console` print methods now print the ansi reset character at the end as well to reset colours.