### PR TITLE
Non static parsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
                                 <exclude>nl.tudelft.goalkeeper.parser.results.parts.MessageMood</exclude>
                                 <exclude>nl.tudelft.goalkeeper.parser.results.files.module.actions.InternalActionType</exclude>
                                 <exclude>nl.tudelft.goalkeeper.parser.results.parts.KRLanguage</exclude>
+                                <exclude>nl.tudelft.goalkeeper.parser.results.files.module.parsers.ModuleParser</exclude>
                             </excludes>
                             <limits>
                                 <limit>

--- a/src/main/java/nl/tudelft/goalkeeper/checking/violations/source/SourceParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/checking/violations/source/SourceParser.java
@@ -8,16 +8,11 @@ import krTools.parser.SourceInfo;
 public final class SourceParser {
 
     /**
-     * Prevents instantiation.
-     */
-    private SourceParser() { }
-
-    /**
      * Parses a GOAL SourceInfo object to a GOALkeeper Source object.
      * @param sourceInfo SourceInfo object to parse.
      * @return Source object result.
      */
-    public static Source parse(SourceInfo sourceInfo) {
+    public Source parse(SourceInfo sourceInfo) {
         String file = sourceInfo.getSource();
         int line = sourceInfo.getLineNumber();
         int position = sourceInfo.getCharacterPosition();

--- a/src/main/java/nl/tudelft/goalkeeper/parser/Parser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/Parser.java
@@ -4,6 +4,8 @@ import languageTools.analyzer.FileRegistry;
 import languageTools.analyzer.mas.Analysis;
 import languageTools.analyzer.mas.MASValidator;
 import languageTools.errors.Message;
+import lombok.Getter;
+import lombok.Setter;
 import nl.tudelft.goalkeeper.parser.results.ParseResult;
 import languageTools.program.agent.Module;
 import nl.tudelft.goalkeeper.parser.results.files.module.parsers.MessageParser;
@@ -15,6 +17,17 @@ import java.io.IOException;
  * Parses a MAS and returns the parsed data.
  */
 public final class Parser {
+
+    @Getter @Setter private MessageParser messageParser;
+    @Getter @Setter private ModuleParser moduleParser;
+
+    /**
+     * Creates a new Parser instance.
+     */
+    public Parser() {
+        messageParser = new MessageParser();
+        moduleParser = new ModuleParser();
+    }
 
     /**
      * Parses the mas from given file path.
@@ -29,21 +42,21 @@ public final class Parser {
         Analysis analysis = validator.process();
 
         for (Message error : validator.getErrors()) {
-            result.addViolation(MessageParser.parse(error));
+            result.addViolation(messageParser.parse(error));
             result.setSuccessful(false);
         }
         for (Message error : validator.getSyntaxErrors()) {
-            result.addViolation(MessageParser.parse(error));
+            result.addViolation(messageParser.parse(error));
             result.setSuccessful(false);
         }
         for (Message error : validator.getWarnings()) {
-            result.addViolation(MessageParser.parse(error).setError(false));
+            result.addViolation(messageParser.parse(error).setError(false));
         }
 
         if (result.isSuccessful()) {
             for (Module m : analysis.getModuleDefinitions()) {
                 try {
-                    result.addModule(ModuleParser.parseToFile(m));
+                    result.addModule(moduleParser.parseToFile(m));
                 } catch (IOException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/nl/tudelft/goalkeeper/parser/Parser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/Parser.java
@@ -20,24 +20,25 @@ public final class Parser {
 
     @Getter @Setter private MessageParser messageParser;
     @Getter @Setter private ModuleParser moduleParser;
+    @Getter @Setter private MASValidator validator;
 
     /**
      * Creates a new Parser instance.
+     * @param fileName File path of a .mas2g file.
      */
-    public Parser() {
+    public Parser(String fileName) {
         messageParser = new MessageParser();
         moduleParser = new ModuleParser();
+        validator = new MASValidator(fileName, new FileRegistry());
     }
 
     /**
      * Parses the mas from given file path.
-     * @param fileName File path of a .mas2g file.
      * @return Results of parsing.
      */
-    public ParseResult parse(String fileName) {
+    public ParseResult parse() {
         ParseResult result = new ParseResult();
         result.setSuccessful(true);
-        MASValidator validator = new MASValidator(fileName, new FileRegistry());
         validator.validate();
         Analysis analysis = validator.process();
 

--- a/src/main/java/nl/tudelft/goalkeeper/parser/Parser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/Parser.java
@@ -43,11 +43,11 @@ public final class Parser {
         Analysis analysis = validator.process();
 
         for (Message error : validator.getErrors()) {
-            result.addViolation(messageParser.parse(error));
+            result.addViolation(messageParser.parse(error).setError(true));
             result.setSuccessful(false);
         }
         for (Message error : validator.getSyntaxErrors()) {
-            result.addViolation(messageParser.parse(error));
+            result.addViolation(messageParser.parse(error).setError(true));
             result.setSuccessful(false);
         }
         for (Message error : validator.getWarnings()) {

--- a/src/main/java/nl/tudelft/goalkeeper/parser/queries/ExpressionParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/queries/ExpressionParser.java
@@ -1,6 +1,8 @@
 package nl.tudelft.goalkeeper.parser.queries;
 
 import krTools.parser.SourceInfo;
+import lombok.Getter;
+import lombok.Setter;
 import nl.tudelft.goalkeeper.checking.violations.source.SourceParser;
 import nl.tudelft.goalkeeper.exceptions.UnknownKRLanguageException;
 import nl.tudelft.goalkeeper.parser.results.parts.Expression;
@@ -11,10 +13,14 @@ import swiprolog.language.PrologExpression;
  */
 public final class ExpressionParser {
 
+    @Getter @Setter private SourceParser sourceParser;
+
     /**
-     * Prevents instantiation.
+     * Creates a new ExpressionParser instance.
      */
-    private ExpressionParser() { }
+    public ExpressionParser() {
+        sourceParser = new SourceParser();
+    }
 
     /**
      * Parses a GOAL query to a GOALkeeper expression.
@@ -22,12 +28,12 @@ public final class ExpressionParser {
      * @return Parsed expression.
      * @throws UnknownKRLanguageException Thrown when we can't handle the query.
      */
-    public static Expression parse(krTools.language.Expression expression)
+    public Expression parse(krTools.language.Expression expression)
             throws UnknownKRLanguageException {
         Expression result = getParser(expression).parse(expression);
         SourceInfo sourceInfo = expression.getSourceInfo();
         if (sourceInfo != null) {
-            result.setSource(SourceParser.parse(sourceInfo));
+            result.setSource(sourceParser.parse(sourceInfo));
         }
         return result;
     }

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParser.java
@@ -34,7 +34,6 @@ public final class ActionParser {
     private static final String SUB_MODULE_PREFIX = "null/";
 
     @Getter @Setter private ExpressionParser expressionParser;
-    @Getter @Setter private ModuleParser subModuleParser;
     @Getter @Setter private SourceParser sourceParser;
 
     /**
@@ -42,7 +41,6 @@ public final class ActionParser {
      */
     public ActionParser() {
         expressionParser = new ExpressionParser();
-        subModuleParser = new ModuleParser();
         sourceParser = new SourceParser();
     }
 
@@ -152,7 +150,7 @@ public final class ActionParser {
      * @return GOALkeeper SubModuleAction version of a.
      */
     private SubModuleAction parseSubModuleAction(ModuleCallAction a) {
-        return new SubModuleAction(subModuleParser.parseToSubModule(a.getTarget()));
+        return new SubModuleAction(new ModuleParser().parseToSubModule(a.getTarget()));
     }
 
     /**

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParser.java
@@ -34,6 +34,7 @@ public final class ActionParser {
     private static final String SUB_MODULE_PREFIX = "null/";
 
     @Getter @Setter private ExpressionParser expressionParser;
+    @Getter @Setter private ModuleParser subModuleParser;
     @Getter @Setter private SourceParser sourceParser;
 
     /**
@@ -41,6 +42,7 @@ public final class ActionParser {
      */
     public ActionParser() {
         expressionParser = new ExpressionParser();
+        subModuleParser = new ModuleParser();
         sourceParser = new SourceParser();
     }
 
@@ -149,8 +151,8 @@ public final class ActionParser {
      * @param a ModuleCallAction to parse.
      * @return GOALkeeper SubModuleAction version of a.
      */
-    private static SubModuleAction parseSubModuleAction(ModuleCallAction a) {
-        return new SubModuleAction(ModuleParser.parseToSubModule(a.getTarget()));
+    private SubModuleAction parseSubModuleAction(ModuleCallAction a) {
+        return new SubModuleAction(subModuleParser.parseToSubModule(a.getTarget()));
     }
 
     /**

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParser.java
@@ -6,6 +6,8 @@ import languageTools.program.agent.actions.ExitModuleAction;
 import languageTools.program.agent.actions.ModuleCallAction;
 import languageTools.program.agent.actions.UserSpecCallAction;
 import languageTools.program.agent.msg.SentenceMood;
+import lombok.Getter;
+import lombok.Setter;
 import nl.tudelft.goalkeeper.checking.violations.source.SourceParser;
 import nl.tudelft.goalkeeper.exceptions.UnknownKRLanguageException;
 import nl.tudelft.goalkeeper.parser.queries.ExpressionParser;
@@ -31,10 +33,16 @@ public final class ActionParser {
 
     private static final String SUB_MODULE_PREFIX = "null/";
 
+    @Getter @Setter private ExpressionParser expressionParser;
+    @Getter @Setter private SourceParser sourceParser;
+
     /**
-     * Prevents instantiation.
+     * Creates a new ActionParser instance.
      */
-    private ActionParser() { }
+    public ActionParser() {
+        expressionParser = new ExpressionParser();
+        sourceParser = new SourceParser();
+    }
 
     /**
      * Parses an action to the GOALkeeper form.
@@ -42,12 +50,12 @@ public final class ActionParser {
      * @return GOALkeeper action.
      * @throws UnknownKRLanguageException Thrown when KR language could not be determined.
      */
-    public static Action parse(languageTools.program.agent.actions.Action a)
+    public Action parse(languageTools.program.agent.actions.Action a)
             throws UnknownKRLanguageException {
         Action action = getInstance(a);
         SourceInfo sourceInfo = a.getSourceInfo();
         if (sourceInfo != null) {
-            action.setSource(SourceParser.parse(sourceInfo));
+            action.setSource(sourceParser.parse(sourceInfo));
         }
         return action;
     }
@@ -58,7 +66,7 @@ public final class ActionParser {
      * @return GOALkeeper action.
      * @throws UnknownKRLanguageException Thrown when KR language could not be determined.
      */
-    private static Action getInstance(languageTools.program.agent.actions.Action a)
+    private Action getInstance(languageTools.program.agent.actions.Action a)
             throws UnknownKRLanguageException {
         if (a instanceof languageTools.program.agent.actions.SendAction) {
             return parseSendAction((languageTools.program.agent.actions.SendAction) a);
@@ -93,10 +101,10 @@ public final class ActionParser {
      * @return Expression of the action. Returns null if there is none.
      * @throws UnknownKRLanguageException Thrown when KR language could not be identified.
      */
-    private static Expression getExpression(languageTools.program.agent.actions.Action a)
+    private Expression getExpression(languageTools.program.agent.actions.Action a)
             throws UnknownKRLanguageException {
         if (a.getParameters().size() > 0) {
-            return ExpressionParser.parse((krTools.language.Expression) a.getParameters().get(0));
+            return expressionParser.parse((krTools.language.Expression) a.getParameters().get(0));
         }
         return null;
     }
@@ -107,11 +115,11 @@ public final class ActionParser {
      * @return GOALkeeper SendAction version of a.
      * @throws UnknownKRLanguageException Thrown when KR language could not be determined.
      */
-    private static SendAction parseSendAction(languageTools.program.agent.actions.SendAction a)
+    private SendAction parseSendAction(languageTools.program.agent.actions.SendAction a)
             throws UnknownKRLanguageException {
         List<Expression> recipients = new LinkedList<>();
         for (Term recipient : a.getSelector().getParameters()) {
-            recipients.add(ExpressionParser.parse(recipient));
+            recipients.add(expressionParser.parse(recipient));
         }
         MessageMood mood = MessageMood.INDICATIVE;
         if (a.getMood().equals(SentenceMood.IMPERATIVE)) {
@@ -128,11 +136,11 @@ public final class ActionParser {
      * @return GOALkeeper StartTimerAction version of a.
      * @throws UnknownKRLanguageException Thrown when KR language could not be determined.
      */
-    private static StartTimerAction parseStartTimerAction(
+    private StartTimerAction parseStartTimerAction(
             languageTools.program.agent.actions.StartTimerAction a)
             throws UnknownKRLanguageException {
-        Expression interval = ExpressionParser.parse(a.getParameters().get(1));
-        Expression duration = ExpressionParser.parse(a.getParameters().get(2));
+        Expression interval = expressionParser.parse(a.getParameters().get(1));
+        Expression duration = expressionParser.parse(a.getParameters().get(2));
         return new StartTimerAction(getExpression(a), interval, duration);
     }
 
@@ -151,11 +159,11 @@ public final class ActionParser {
      * @return GOALkeeper ModuleAction version of a.
      * @throws UnknownKRLanguageException Thrown when KR language could not be determined.
      */
-    private static ModuleAction parseModuleAction(ModuleCallAction a)
+    private ModuleAction parseModuleAction(ModuleCallAction a)
             throws UnknownKRLanguageException {
         List<Expression> arguments = new LinkedList<>();
         for (Term t : a.getParameters()) {
-            arguments.add(ExpressionParser.parse(t));
+            arguments.add(expressionParser.parse(t));
         }
         String source = a.getTarget().getSourceInfo().getSource();
         return new ModuleAction(source, arguments);
@@ -167,11 +175,11 @@ public final class ActionParser {
      * @return GOALkeeper ExternalAction version of a.
      * @throws UnknownKRLanguageException Thrown when KR language could not be determined.
      */
-    private static ExternalAction parseExternalAction(UserSpecCallAction a)
+    private ExternalAction parseExternalAction(UserSpecCallAction a)
             throws UnknownKRLanguageException {
         List<Expression> arguments = new LinkedList<>();
         for (Term t : a.getParameters()) {
-            arguments.add(ExpressionParser.parse(t));
+            arguments.add(expressionParser.parse(t));
         }
         String source = a.getSpecification().getSourceInfo().getSource();
         return new ExternalAction(source, arguments);

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ConditionParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ConditionParser.java
@@ -36,6 +36,7 @@ public final class ConditionParser {
      */
     public ConditionParser() {
         expressionParser = new ExpressionParser();
+        sourceParser = new SourceParser();
     }
 
     /**

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ConditionParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ConditionParser.java
@@ -5,6 +5,8 @@ import krTools.language.Var;
 import krTools.parser.SourceInfo;
 import languageTools.program.agent.msc.MentalLiteral;
 import languageTools.program.agent.selector.Selector;
+import lombok.Getter;
+import lombok.Setter;
 import nl.tudelft.goalkeeper.checking.violations.source.SourceParser;
 import nl.tudelft.goalkeeper.exceptions.UnknownKRLanguageException;
 import nl.tudelft.goalkeeper.parser.queries.ExpressionParser;
@@ -26,10 +28,15 @@ import nl.tudelft.goalkeeper.parser.results.parts.Variable;
  */
 public final class ConditionParser {
 
+    @Getter @Setter private ExpressionParser expressionParser;
+    @Getter @Setter private SourceParser sourceParser;
+
     /**
-     * Prevents instantiation.
+     * Creates a new ConditionParser instance.
      */
-    private ConditionParser() { }
+    public ConditionParser() {
+        expressionParser = new ExpressionParser();
+    }
 
     /**
      * Parses a query to a condition.
@@ -37,13 +44,13 @@ public final class ConditionParser {
      * @return Condition of our own type.
      * @throws UnknownKRLanguageException Thrown when we can'thandle the language.
      */
-    public static Condition parse(MentalLiteral query)
+    public Condition parse(MentalLiteral query)
             throws UnknownKRLanguageException {
-        Expression e = ExpressionParser.parse(query.getFormula());
+        Expression e = expressionParser.parse(query.getFormula());
         Condition condition = getInstance(query.getOperator(), query.getSelector(), e);
         SourceInfo sourceInfo = query.getSourceInfo();
         if (sourceInfo != null) {
-            condition.setSource(SourceParser.parse(sourceInfo));
+            condition.setSource(sourceParser.parse(sourceInfo));
         }
         condition.setKRLanguage(e.getKRLanguage());
         return condition;

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/MessageParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/MessageParser.java
@@ -12,16 +12,11 @@ public final class MessageParser {
     private static final int SYNTAX_SEVERITY = 1;
 
     /**
-     * Prevents instantiation.
-     */
-    private MessageParser() { }
-
-    /**
      * Convert error message to a violation.
      * @param error Error message to parse.
      * @return Violation.
      */
-    public static Violation parse(Message error) {
+    public Violation parse(Message error) {
         return new Violation(error.toShortString(), SYNTAX_SEVERITY)
                 .setSource(new CharacterSource(
                         error.getSource().getSource(),

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ModuleParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ModuleParser.java
@@ -1,5 +1,7 @@
 package nl.tudelft.goalkeeper.parser.results.files.module.parsers;
 
+import lombok.Getter;
+import lombok.Setter;
 import nl.tudelft.goalkeeper.checking.violations.source.LineSource;
 import nl.tudelft.goalkeeper.parser.results.files.module.Module;
 import nl.tudelft.goalkeeper.parser.results.files.module.ModuleFile;
@@ -19,10 +21,14 @@ import java.util.List;
  */
 public final class ModuleParser {
 
+    @Getter @Setter private RuleParser ruleParser;
+
     /**
-     * Prevents instantiation.
+     * Creates a ModuleParser instance.
      */
-    private ModuleParser() { }
+    public ModuleParser() {
+        ruleParser = new RuleParser();
+    }
 
     /**
      * Parses a GOAL module to a GOALkeeper module file.
@@ -30,7 +36,7 @@ public final class ModuleParser {
      * @return GOALkeeper module file.
      * @throws IOException Thrown when there is a problem reading the file.
      */
-    public static ModuleFile parseToFile(languageTools.program.agent.Module m) throws IOException {
+    public ModuleFile parseToFile(languageTools.program.agent.Module m) throws IOException {
         ModuleFile module = new ModuleFile(m.getSourceFile().toString());
         addRules(module, m);
         module.setName(m.getName());
@@ -87,7 +93,7 @@ public final class ModuleParser {
      * @param m Module to parse.
      * @return GOALkeeper submodule.
      */
-    public static SubModule parseToSubModule(languageTools.program.agent.Module m) {
+    public SubModule parseToSubModule(languageTools.program.agent.Module m) {
         SubModule module = new SubModule();
         addRules(module, m);
         return module;
@@ -98,9 +104,9 @@ public final class ModuleParser {
      * @param target Target module.
      * @param source Source module type.
      */
-    private static void addRules(Module target, languageTools.program.agent.Module source) {
+    private void addRules(Module target, languageTools.program.agent.Module source) {
         for (languageTools.program.agent.rules.Rule r : source.getRules()) {
-            target.addRule(RuleParser.parse(r));
+            target.addRule(ruleParser.parse(r));
         }
     }
 }

--- a/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/RuleParser.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/RuleParser.java
@@ -2,6 +2,8 @@ package nl.tudelft.goalkeeper.parser.results.files.module.parsers;
 
 import languageTools.program.agent.rules.ForallDoRule;
 import languageTools.program.agent.rules.ListallDoRule;
+import lombok.Getter;
+import lombok.Setter;
 import nl.tudelft.goalkeeper.checking.violations.source.BlockSource;
 import nl.tudelft.goalkeeper.checking.violations.source.CharacterSource;
 import nl.tudelft.goalkeeper.checking.violations.source.LineSource;
@@ -17,10 +19,16 @@ import nl.tudelft.goalkeeper.parser.results.parts.KRLanguage;
  */
 public final class RuleParser {
 
+    @Getter @Setter private ConditionParser conditionParser;
+    @Getter @Setter private ActionParser actionParser;
+
     /**
-     * Prevents instantiation.
+     * Creates a new RuleParser instance.
      */
-    private RuleParser() { }
+    public RuleParser() {
+        conditionParser = new ConditionParser();
+        actionParser = new ActionParser();
+    }
 
     /**
      * Parses a rule.
@@ -28,7 +36,7 @@ public final class RuleParser {
      * @return GOALkeeper rule version of the rule.
      */
     @SuppressWarnings("MethodLength")
-    public static Rule parse(languageTools.program.agent.rules.Rule r) {
+    public Rule parse(languageTools.program.agent.rules.Rule r) {
         Rule rule = new Rule(getType(r));
         String fileName = "";
         int startingLine = Integer.MAX_VALUE;
@@ -37,7 +45,7 @@ public final class RuleParser {
         for (languageTools.program.agent.msc.MentalLiteral l
                 : r.getCondition().getAllLiterals()) {
             try {
-                Condition c = ConditionParser.parse(l);
+                Condition c = conditionParser.parse(l);
                 rule.addCondition(c);
                 if (c.getSource() != null && c.getSource() instanceof CharacterSource) {
                     CharacterSource source = (CharacterSource) c.getSource();
@@ -54,7 +62,7 @@ public final class RuleParser {
         }
         for (languageTools.program.agent.actions.Action<?> a : r.getAction().getActions()) {
             try {
-                Action action = ActionParser.parse(a);
+                Action action = actionParser.parse(a);
                 rule.addAction(action);
                 if (action.getSource() != null && action.getSource() instanceof CharacterSource) {
                     CharacterSource source = (CharacterSource) action.getSource();

--- a/src/test/java/nl/tudelft/goalkeeper/checking/violations/source/SourceParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/checking/violations/source/SourceParserTest.java
@@ -34,7 +34,7 @@ class SourceParserTest {
      */
     @Test
     void parseTest() {
-        Source s = SourceParser.parse(si);
+        Source s = new SourceParser().parse(si);
         assertThat(s.getFile()).isEqualTo(FILE_NAME);
         assertThat(s).isInstanceOf(CharacterSource.class);
         CharacterSource cs = (CharacterSource) s;

--- a/src/test/java/nl/tudelft/goalkeeper/parser/ParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/ParserTest.java
@@ -1,8 +1,20 @@
 package nl.tudelft.goalkeeper.parser;
 
+import languageTools.analyzer.mas.Analysis;
+import languageTools.analyzer.mas.MASValidator;
+import languageTools.errors.Message;
+import languageTools.program.agent.Module;
+import nl.tudelft.goalkeeper.checking.violations.Violation;
 import nl.tudelft.goalkeeper.parser.results.ParseResult;
+import nl.tudelft.goalkeeper.parser.results.files.module.parsers.MessageParser;
+import nl.tudelft.goalkeeper.parser.results.files.module.parsers.ModuleParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,27 +23,93 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ParserTest {
 
+    private Parser parser;
+    private MASValidator validator;
+    private MessageParser messageParser;
+    private ModuleParser moduleParser;
+    private Violation violation;
+    private Message message;
+    private Analysis analysis;
+
     /**
-     * Checks that we can correctly parse failing mas files.
+     * Sets up the testing environment before each test.
+     */
+    @BeforeEach
+    void setup() {
+        parser = new Parser("");
+        validator = Mockito.mock(MASValidator.class);
+        messageParser = Mockito.mock(MessageParser.class);
+        violation = Mockito.mock(Violation.class);
+        message = Mockito.mock(Message.class);
+        moduleParser = Mockito.mock(ModuleParser.class);
+        parser.setValidator(validator);
+        parser.setMessageParser(messageParser);
+        parser.setModuleParser(moduleParser);
+        Mockito.when(messageParser.parse(message)).thenReturn(violation);
+        Mockito.when(validator.getErrors()).thenReturn(new TreeSet<>());
+        Mockito.when(validator.getSyntaxErrors()).thenReturn(new TreeSet<>());
+        Mockito.when(validator.getWarnings()).thenReturn(new TreeSet<>());
+        analysis = Mockito.mock(Analysis.class);
+        Mockito.when(validator.process()).thenReturn(analysis);
+        Mockito.when(analysis.getModuleDefinitions()).thenReturn(new HashSet<>());
+    }
+
+    /**
+     * Checks that we can correctly parse a mas file with an error.
      */
     @Test
-    void failureTest() {
-        ParseResult result = new Parser("src/test/resources/testfiles/failed.mas2g").parse();
-        assertThat(result.getViolations()).hasSize(4);
+    void errorTest() {
+        validator.getErrors().add(message);
+        ParseResult result = parser.parse();
         assertThat(result.isSuccessful()).isFalse();
-        assertThat(result.getViolations()).filteredOn(o -> o.isError()).hasSize(3);
-        assertThat(result.getViolations()).filteredOn(o -> !o.isError()).hasSize(1);
+        assertThat(result.getViolations()).hasSize(1);
+        Mockito.verify(messageParser, Mockito.times(1)).parse(message);
+        Mockito.verify(violation, Mockito.times(1)).setError(true);
+    }
+
+    /**
+     * Checks that we can correctly parse a mas file with a syntax error.
+     */
+    @Test
+    void syntaxErrorTest() {
+        validator.getSyntaxErrors().add(message);
+        ParseResult result = parser.parse();
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getViolations()).hasSize(1);
+        Mockito.verify(messageParser, Mockito.times(1)).parse(message);
+        Mockito.verify(violation, Mockito.times(1)).setError(true);
+    }
+
+    /**
+     * Checks that we can correctly parse a mas file with a warning.
+     */
+    @Test
+    void warningTest() {
+        validator.getWarnings().add(message);
+        ParseResult result = parser.parse();
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(result.getViolations()).hasSize(1);
+        Mockito.verify(messageParser, Mockito.times(1)).parse(message);
+        Mockito.verify(violation, Mockito.times(1)).setError(false);
     }
 
     /**
      * Add checks for correct files.
      */
     @Test
-    void successTest() {
-        ParseResult result = new Parser("src/test/resources/testfiles/bw4t-working/bw4t.mas2g").parse();
-        assertThat(result.getViolations()).hasSize(1);
+    void successTest() throws IOException {
+        Module m1 = Mockito.mock(Module.class);
+        Module m2 = Mockito.mock(Module.class);
+        analysis.getModuleDefinitions().add(m1);
+        analysis.getModuleDefinitions().add(m2);
+
+        ParseResult result = parser.parse();
         assertThat(result.isSuccessful()).isTrue();
-        assertThat(result.getViolations()).filteredOn(o -> o.isError()).hasSize(0);
-        assertThat(result.getViolations()).filteredOn(o -> !o.isError()).hasSize(1);
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(result.getViolations()).isEmpty();
+        assertThat(result.getModules()).hasSize(2);
+
+        Mockito.verify(moduleParser, Mockito.times(1)).parseToFile(m1);
+        Mockito.verify(moduleParser, Mockito.times(1)).parseToFile(m2);
     }
 }

--- a/src/test/java/nl/tudelft/goalkeeper/parser/ParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/ParserTest.java
@@ -11,22 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ParserTest {
 
-    private Parser parser;
-
-    /**
-     * Sets up test environment before each test.
-     */
-    @BeforeEach
-    void setup() {
-        parser = new Parser();
-    }
-
     /**
      * Checks that we can correctly parse failing mas files.
      */
     @Test
     void failureTest() {
-        ParseResult result = parser.parse("src/test/resources/testfiles/failed.mas2g");
+        ParseResult result = new Parser("src/test/resources/testfiles/failed.mas2g").parse();
         assertThat(result.getViolations()).hasSize(4);
         assertThat(result.isSuccessful()).isFalse();
         assertThat(result.getViolations()).filteredOn(o -> o.isError()).hasSize(3);
@@ -38,7 +28,7 @@ class ParserTest {
      */
     @Test
     void successTest() {
-        ParseResult result = parser.parse("src/test/resources/testfiles/bw4t-working/bw4t.mas2g");
+        ParseResult result = new Parser("src/test/resources/testfiles/bw4t-working/bw4t.mas2g").parse();
         assertThat(result.getViolations()).hasSize(1);
         assertThat(result.isSuccessful()).isTrue();
         assertThat(result.getViolations()).filteredOn(o -> o.isError()).hasSize(0);

--- a/src/test/java/nl/tudelft/goalkeeper/parser/queries/ExpressionParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/queries/ExpressionParserTest.java
@@ -57,7 +57,7 @@ class ExpressionParserTest {
         Term term = Mockito.mock(Term.class);
         Mockito.when(term.isVariable()).thenReturn(true);
         Mockito.when(query.getTerm()).thenReturn(term);
-        CharacterSource source = (CharacterSource) ExpressionParser.parse(query).getSource();
+        CharacterSource source = (CharacterSource) new ExpressionParser().parse(query).getSource();
         assertThat(source.getFile()).isEqualTo(FILE_NAME);
         assertThat(source.getLine()).isEqualTo(LINE_NUMBER);
         assertThat(source.getPosition()).isEqualTo(CHARACTER_POSITION);

--- a/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ActionParserTest.java
@@ -41,10 +41,13 @@ class ActionParserTest {
     private languageTools.program.agent.actions.Action input;
     private PrologTerm expression;
 
+    private ActionParser parser;
+
     /**
      * Sets up the testing environment before each test.
      */
     private void setup(Class<? extends languageTools.program.agent.actions.Action> type) {
+        parser = new ActionParser();
         expression = Mockito.mock(PrologTerm.class);
         Term term = Mockito.mock(Term.class);
         Mockito.when(expression.getTerm()).thenReturn(term);
@@ -65,12 +68,12 @@ class ActionParserTest {
         Mockito.when(selector.getParameters()).thenReturn(Collections.singletonList(expression));
         Mockito.when(sa.getSelector()).thenReturn(selector);
         Mockito.when((sa).getMood()).thenReturn(SentenceMood.IMPERATIVE);
-        assertThat(ActionParser.parse(input)).isInstanceOf(SendAction.class);
-        assertThat(((SendAction)ActionParser.parse(input)).getMood()).isEqualTo(MessageMood.IMPERATIVE);
+        assertThat(parser.parse(input)).isInstanceOf(SendAction.class);
+        assertThat(((SendAction)parser.parse(input)).getMood()).isEqualTo(MessageMood.IMPERATIVE);
         Mockito.when((sa).getMood()).thenReturn(SentenceMood.INDICATIVE);
-        assertThat(((SendAction)ActionParser.parse(input)).getMood()).isEqualTo(MessageMood.INDICATIVE);
+        assertThat(((SendAction)parser.parse(input)).getMood()).isEqualTo(MessageMood.INDICATIVE);
         Mockito.when((sa).getMood()).thenReturn(SentenceMood.INTERROGATIVE);
-        assertThat(((SendAction)ActionParser.parse(input)).getMood()).isEqualTo(MessageMood.INTERROGATIVE);
+        assertThat(((SendAction)parser.parse(input)).getMood()).isEqualTo(MessageMood.INTERROGATIVE);
     }
 
     /**
@@ -80,7 +83,7 @@ class ActionParserTest {
     void exitActionTest()
             throws UnknownKRLanguageException {
         setup(ExitModuleAction.class);
-        assertThat(ActionParser.parse(input)).isInstanceOf(ExitAction.class);
+        assertThat(parser.parse(input)).isInstanceOf(ExitAction.class);
     }
 
     /**
@@ -91,7 +94,7 @@ class ActionParserTest {
             throws UnknownKRLanguageException {
         setup(languageTools.program.agent.actions.StartTimerAction.class);
         Mockito.when(input.getParameters()).thenReturn(Arrays.asList(expression, expression, expression));
-        assertThat(ActionParser.parse(input)).isInstanceOf(StartTimerAction.class);
+        assertThat(parser.parse(input)).isInstanceOf(StartTimerAction.class);
     }
 
     /**
@@ -105,7 +108,7 @@ class ActionParserTest {
         Module module = Mockito.mock(Module.class);
         Mockito.when(module.getRules()).thenReturn(new ArrayList<>());
         Mockito.when(((ModuleCallAction)input).getTarget()).thenReturn(module);
-        assertThat(ActionParser.parse(input)).isInstanceOf(SubModuleAction.class);
+        assertThat(parser.parse(input)).isInstanceOf(SubModuleAction.class);
     }
 
     /**
@@ -122,8 +125,8 @@ class ActionParserTest {
         Mockito.when(module.getSourceInfo()).thenReturn(source);
         Mockito.when(source.getSource()).thenReturn("AMAZING SOURCE");
         Mockito.when(((ModuleCallAction)input).getTarget()).thenReturn(module);
-        assertThat(ActionParser.parse(input)).isInstanceOf(ModuleAction.class);
-        assertThat(((ModuleAction)ActionParser.parse(input)).getTarget()).isEqualTo("AMAZING SOURCE");
+        assertThat(parser.parse(input)).isInstanceOf(ModuleAction.class);
+        assertThat(((ModuleAction)parser.parse(input)).getTarget()).isEqualTo("AMAZING SOURCE");
     }
 
     /**
@@ -138,8 +141,8 @@ class ActionParserTest {
         SourceInfo source = Mockito.mock(SourceInfo.class);
         Mockito.when(spec.getSourceInfo()).thenReturn(source);
         Mockito.when(source.getSource()).thenReturn("LAME SOURCE");
-        assertThat(ActionParser.parse(input)).isInstanceOf(ExternalAction.class);
-        assertThat(((ExternalAction)ActionParser.parse(input)).getTarget()).isEqualTo("LAME SOURCE");
+        assertThat(parser.parse(input)).isInstanceOf(ExternalAction.class);
+        assertThat(((ExternalAction)parser.parse(input)).getTarget()).isEqualTo("LAME SOURCE");
     }
 
     /**
@@ -150,15 +153,15 @@ class ActionParserTest {
             throws UnknownKRLanguageException {
         setup(NonMentalAction.class);
         Mockito.when(input.getSignature()).thenReturn("print/1");
-        assertThat(ActionParser.parse(input)).isInstanceOf(InternalAction.class);
-        assertThat(ActionParser.parse(input).getIdentifier()).isEqualTo("print/1");
+        assertThat(parser.parse(input)).isInstanceOf(InternalAction.class);
+        assertThat(parser.parse(input).getIdentifier()).isEqualTo("print/1");
         Mockito.when(input.getSignature()).thenReturn("log/1");
-        assertThat(ActionParser.parse(input)).isInstanceOf(InternalAction.class);
-        assertThat(ActionParser.parse(input).getIdentifier()).isEqualTo("log/1");
+        assertThat(parser.parse(input)).isInstanceOf(InternalAction.class);
+        assertThat(parser.parse(input).getIdentifier()).isEqualTo("log/1");
         //TODO: Remove the following lines when goal fixes the copy paste error.
         Mockito.when(input.getSignature()).thenReturn("starttimer/1");
-        assertThat(ActionParser.parse(input)).isInstanceOf(InternalAction.class);
-        assertThat(ActionParser.parse(input).getIdentifier()).isEqualTo("canceltimer/1");
+        assertThat(parser.parse(input)).isInstanceOf(InternalAction.class);
+        assertThat(parser.parse(input).getIdentifier()).isEqualTo("canceltimer/1");
     }
 
     /**
@@ -172,7 +175,7 @@ class ActionParserTest {
         Mockito.when(si.getLineNumber()).thenReturn(LINE_NUMBER);
         Mockito.when(si.getCharacterPosition()).thenReturn(CHARACTER_POSITION);
         Mockito.when(input.getSourceInfo()).thenReturn(si);
-        CharacterSource output = (CharacterSource) ActionParser.parse(input).getSource();
+        CharacterSource output = (CharacterSource) parser.parse(input).getSource();
         assertThat(output.getFile()).isEqualTo(FILE_NAME);
         assertThat(output.getLine()).isEqualTo(LINE_NUMBER);
         assertThat(output.getPosition()).isEqualTo(CHARACTER_POSITION);

--- a/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ConditionParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ConditionParserTest.java
@@ -52,11 +52,14 @@ class ConditionParserTest {
     private Term term;
     private jpl.Term pTerm;
 
+    private ConditionParser parser;
+
     /**
      * Sets up the testing environment before each test.
      */
     @BeforeEach
     void setup() {
+        parser = new ConditionParser();
         literal = Mockito.mock(MentalLiteral.class);
         selector = Mockito.mock(Selector.class);
         query = Mockito.mock(PrologQuery.class);
@@ -77,7 +80,7 @@ class ConditionParserTest {
     @Test
     void perceptTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(PERCEPT);
-        assertThat(ConditionParser.parse(literal)).isInstanceOf(PerceptCondition.class);
+        assertThat(parser.parse(literal)).isInstanceOf(PerceptCondition.class);
     }
 
     /**
@@ -86,7 +89,7 @@ class ConditionParserTest {
     @Test
     void beliefTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(BELIEF);
-        assertThat(ConditionParser.parse(literal)).isInstanceOf(BeliefCondition.class);
+        assertThat(parser.parse(literal)).isInstanceOf(BeliefCondition.class);
     }
 
     /**
@@ -95,7 +98,7 @@ class ConditionParserTest {
     @Test
     void goalTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(GOAL);
-        assertThat(ConditionParser.parse(literal)).isInstanceOf(GoalCondition.class);
+        assertThat(parser.parse(literal)).isInstanceOf(GoalCondition.class);
     }
 
     /**
@@ -104,7 +107,7 @@ class ConditionParserTest {
     @Test
     void aGoalTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(AGOAL);
-        assertThat(ConditionParser.parse(literal)).isInstanceOf(AGoalCondition.class);
+        assertThat(parser.parse(literal)).isInstanceOf(AGoalCondition.class);
     }
 
     /**
@@ -113,7 +116,7 @@ class ConditionParserTest {
     @Test
     void goalATest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(GOALA);
-        assertThat(ConditionParser.parse(literal)).isInstanceOf(GoalACondition.class);
+        assertThat(parser.parse(literal)).isInstanceOf(GoalACondition.class);
     }
 
     /**
@@ -122,7 +125,7 @@ class ConditionParserTest {
     @Test
     void sentIndicativeTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(SENT_INDICATIVE);
-        Condition c = ConditionParser.parse(literal);
+        Condition c = parser.parse(literal);
         assertThat(c).isInstanceOf(SentCondition.class);
         SentCondition sc = (SentCondition) c;
         assertThat(sc.getMood()).isEqualTo(MessageMood.INDICATIVE);
@@ -135,7 +138,7 @@ class ConditionParserTest {
     @Test
     void sentImperativeTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(SENT_IMPERATIVE);
-        Condition c = ConditionParser.parse(literal);
+        Condition c = parser.parse(literal);
         assertThat(c).isInstanceOf(SentCondition.class);
         SentCondition sc = (SentCondition) c;
         assertThat(sc.getMood()).isEqualTo(MessageMood.IMPERATIVE);
@@ -148,7 +151,7 @@ class ConditionParserTest {
     @Test
     void sentInterrogativeTest() throws UnknownKRLanguageException {
         Mockito.when(literal.getOperator()).thenReturn(SENT_INTERROGATIVE);
-        Condition c = ConditionParser.parse(literal);
+        Condition c = parser.parse(literal);
         assertThat(c).isInstanceOf(SentCondition.class);
         SentCondition sc = (SentCondition) c;
         assertThat(sc.getMood()).isEqualTo(MessageMood.INTERROGATIVE);
@@ -164,7 +167,7 @@ class ConditionParserTest {
         Mockito.when(selector.getParameters()).thenReturn(Collections.singletonList(term));
         Mockito.when(term.getSignature()).thenReturn(SIGNATURE);
         Mockito.when(literal.getOperator()).thenReturn(SENT_INTERROGATIVE);
-        SentCondition sc = (SentCondition) ConditionParser.parse(literal);
+        SentCondition sc = (SentCondition) parser.parse(literal);
         assertThat(sc.getSender()).isEqualTo(new Constant(SIGNATURE));
     }
 
@@ -175,7 +178,7 @@ class ConditionParserTest {
     void noSelectorTest() throws UnknownKRLanguageException {
         Mockito.when(selector.getParameters()).thenReturn(new ArrayList<>());
         Mockito.when(literal.getOperator()).thenReturn(SENT_INTERROGATIVE);
-        SentCondition sc = (SentCondition) ConditionParser.parse(literal);
+        SentCondition sc = (SentCondition) parser.parse(literal);
         assertThat(sc.getSender()).isEqualTo(null);
     }
 
@@ -190,7 +193,7 @@ class ConditionParserTest {
         Mockito.when(si.getLineNumber()).thenReturn(LINE_NUMBER);
         Mockito.when(si.getCharacterPosition()).thenReturn(CHARACTER_POSITION);
         Mockito.when(literal.getSourceInfo()).thenReturn(si);
-        CharacterSource source = (CharacterSource) ConditionParser.parse(literal).getSource();
+        CharacterSource source = (CharacterSource) parser.parse(literal).getSource();
         assertThat(source.getFile()).isEqualTo(FILE_NAME);
         assertThat(source.getLine()).isEqualTo(LINE_NUMBER);
         assertThat(source.getPosition()).isEqualTo(CHARACTER_POSITION);

--- a/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/MessageParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/MessageParserTest.java
@@ -26,7 +26,7 @@ class MessageParserTest {
         Mockito.when(si.getLineNumber()).thenReturn(23);
         Mockito.when(si.getStartIndex()).thenReturn(12);
         Mockito.when(si.getSource()).thenReturn("foobar");
-        Violation violation = MessageParser.parse(error);
+        Violation violation = new MessageParser().parse(error);
         assertThat(((CharacterSource) violation.getSource()).getLine()).isEqualTo(23);
         assertThat(((CharacterSource) violation.getSource()).getPosition()).isEqualTo(12);
         assertThat(violation.getSource().getFile()).isEqualTo("foobar");

--- a/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ModuleParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ModuleParserTest.java
@@ -27,11 +27,14 @@ class ModuleParserTest {
 
     private Module module;
 
+    private ModuleParser parser;
+
     /**
      * Sets up the testing environment before each test.
      */
     @BeforeEach
     void setup() {
+        parser = new ModuleParser();
         module = Mockito.mock(Module.class);
         File file = new File(SOURCE);
         Mockito.when(module.getSourceFile()).thenReturn(file);
@@ -42,7 +45,7 @@ class ModuleParserTest {
      */
     @Test
     void emptyTest() throws IOException {
-        ModuleFile mf = ModuleParser.parseToFile(module);
+        ModuleFile mf = parser.parseToFile(module);
         assertThat(mf.getRules()).isEmpty();
         assertThat(mf.getKRLanguage()).isEqualTo(KRLanguage.UNKNOWN);
     }
@@ -60,7 +63,7 @@ class ModuleParserTest {
         Mockito.when(rule.getAction()).thenReturn(ac);
         Mockito.when(msc.getAllLiterals()).thenReturn(new ArrayList<>());
         Mockito.when(ac.getActions()).thenReturn(new ArrayList<>());
-        ModuleFile mf = ModuleParser.parseToFile(module);
+        ModuleFile mf = parser.parseToFile(module);
         assertThat(mf.getRules()).hasSize(1);
     }
 
@@ -77,7 +80,7 @@ class ModuleParserTest {
         Mockito.when(rule.getAction()).thenReturn(ac);
         Mockito.when(msc.getAllLiterals()).thenReturn(new ArrayList<>());
         Mockito.when(ac.getActions()).thenReturn(new ArrayList<>());
-        SubModule mf = ModuleParser.parseToSubModule(module);
+        SubModule mf = parser.parseToSubModule(module);
         assertThat(mf.getRules()).hasSize(1);
     }
 
@@ -87,7 +90,7 @@ class ModuleParserTest {
     @Test
     void getNameTest() throws IOException {
         Mockito.when(module.getName()).thenReturn("WAF");
-        ModuleFile mf = ModuleParser.parseToFile(module);
+        ModuleFile mf = parser.parseToFile(module);
         assertThat(mf.getName()).isEqualTo("WAF");
     }
 }

--- a/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ModuleParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/ModuleParserTest.java
@@ -93,4 +93,20 @@ class ModuleParserTest {
         ModuleFile mf = parser.parseToFile(module);
         assertThat(mf.getName()).isEqualTo("WAF");
     }
+
+    /**
+     * Checks that the KRLanguage is correctly set.
+     */
+    @Test
+    void krLanguageTest() throws IOException {
+        Mockito.when(module.getRules()).thenReturn(Collections.singletonList(null));
+        RuleParser ruleParser = Mockito.mock(RuleParser.class);
+        nl.tudelft.goalkeeper.parser.results.files.module.Rule rule
+                = Mockito.mock(nl.tudelft.goalkeeper.parser.results.files.module.Rule.class);
+        Mockito.when(rule.getKRLanguage()).thenReturn(KRLanguage.PROLOG);
+        Mockito.when(ruleParser.parse(Mockito.any())).thenReturn(rule);
+        parser.setRuleParser(ruleParser);
+        ModuleFile mf = parser.parseToFile(module);
+        assertThat(mf.getKRLanguage()).isEqualTo(KRLanguage.PROLOG);
+    }
 }

--- a/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/RuleParserTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/results/files/module/parsers/RuleParserTest.java
@@ -38,11 +38,14 @@ class RuleParserTest {
     private List<MentalLiteral> conditions;
     private List<Action<?>> actions;
 
+    private RuleParser parser;
+
     /**
      * Sets up the testing environment before each test.
      */
     @BeforeEach
     void setup() {
+        parser = new RuleParser();
         conditions = new ArrayList<>();
         actions = new ArrayList<>();
         rule = Mockito.mock(ListallDoRule.class);
@@ -59,7 +62,7 @@ class RuleParserTest {
      */
     @Test
     void getTypeListAllTest() {
-        assertThat(RuleParser.parse(rule).getType()).isEqualTo(RuleType.LISTALL);
+        assertThat(parser.parse(rule).getType()).isEqualTo(RuleType.LISTALL);
     }
 
     /**
@@ -77,12 +80,12 @@ class RuleParserTest {
         Selector selector = Mockito.mock(Selector.class);
         Mockito.when(lit.getSelector()).thenReturn(selector);
         Mockito.when(selector.getParameters()).thenReturn(new ArrayList<>());
-        assertThat(RuleParser.parse(rule).getConditions()).hasSize(0);
+        assertThat(parser.parse(rule).getConditions()).hasSize(0);
         conditions.add(lit);
-        assertThat(RuleParser.parse(rule).getConditions()).hasSize(1);
+        assertThat(parser.parse(rule).getConditions()).hasSize(1);
         conditions.add(lit);
-        assertThat(RuleParser.parse(rule).getConditions()).hasSize(2);
-        assertThat(RuleParser.parse(rule).getKRLanguage()).isEqualTo(KRLanguage.PROLOG);
+        assertThat(parser.parse(rule).getConditions()).hasSize(2);
+        assertThat(parser.parse(rule).getKRLanguage()).isEqualTo(KRLanguage.PROLOG);
     }
 
     /**
@@ -99,11 +102,11 @@ class RuleParserTest {
         Selector selector = Mockito.mock(Selector.class);
         Mockito.when(selector.getParameters()).thenReturn(new ArrayList<>());
         Mockito.when(action.getSignature()).thenReturn("exit-module/0");
-        assertThat(RuleParser.parse(rule).getActions()).hasSize(0);
+        assertThat(parser.parse(rule).getActions()).hasSize(0);
         actions.add(action);
-        assertThat(RuleParser.parse(rule).getActions()).hasSize(1);
+        assertThat(parser.parse(rule).getActions()).hasSize(1);
         actions.add(action);
-        assertThat(RuleParser.parse(rule).getActions()).hasSize(2);
+        assertThat(parser.parse(rule).getActions()).hasSize(2);
     }
 
     /**
@@ -126,7 +129,7 @@ class RuleParserTest {
         Mockito.when(asi.getLineNumber()).thenReturn(ENDING_LINE);
         Mockito.when(action.getSourceInfo()).thenReturn(asi);
         actions.add(action);
-        Source source = RuleParser.parse(rule).getSource();
+        Source source = parser.parse(rule).getSource();
         assertThat(source.getFile()).isEqualTo(FILE_NAME);
         assertThat(source).isInstanceOf(LineSource.class);
         assertThat(((LineSource) source).getLine()).isEqualTo(ENDING_LINE);
@@ -139,7 +142,7 @@ class RuleParserTest {
         Mockito.when(csi.getLineNumber()).thenReturn(STARTING_LINE);
         Mockito.when(lit.getSourceInfo()).thenReturn(csi);
         conditions.add(lit);
-        source = RuleParser.parse(rule).getSource();
+        source = parser.parse(rule).getSource();
         assertThat(source.getFile()).isEqualTo(FILE_NAME);
         assertThat(source).isInstanceOf(BlockSource.class);
         assertThat(((BlockSource) source).getStartingLine()).isEqualTo(STARTING_LINE);


### PR DESCRIPTION
Resolves #57

#### Changes:
- Parser classes are no longer utility classes and the `.parse(...)` methods are now instance bound.
- Parsers now contain instances of the other parsers they use.
- `ParserTest` now no longer actually parses files, but instead uses mocks for everything.

#### Notes:
- `ActionParser` class can't contain a `ModuleParser` class because it will cause an infinite loop. This should be dealt with probably.
