### PR TITLE
New checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: mvn dependency:go-offline
-
       - save_cache:
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
+      - run: mvn dependency:go-offline
+
       - save_cache:
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: t1mo/oraclejdk8-maven:latest
+      - image: maven:3.5.3-jdk-8-alpine
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: maven:3.5.3-jdk-8-alpine
+      - image: maven:3.5.3-jdk-8
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
                                 <exclude>nl.tudelft.goalkeeper.parser.results.parts.KRLanguage</exclude>
                                 <exclude>nl.tudelft.goalkeeper.parser.results.files.module.parsers.ModuleParser</exclude>
                                 <exclude>nl.tudelft.goalkeeper.parser.results.files.actionspec.parsers.ActionSpecParser</exclude>
+                                <exclude>nl.tudelft.goalkeeper.checking.CheckerRunner</exclude>
                             </excludes>
                             <limits>
                                 <limit>

--- a/src/main/java/nl/tudelft/goalkeeper/Program.java
+++ b/src/main/java/nl/tudelft/goalkeeper/Program.java
@@ -38,6 +38,7 @@ public final class Program {
         validateConfiguration();
 
         Console.println("Acquiring files...");
+        verifyMas(); //TODO: Remove/replace this.
 
         Console.println("Acquiring rules...");
         RuleSet rules = getRuleSet();
@@ -83,6 +84,27 @@ public final class Program {
         }
         System.exit(ExitCode.NO_RULES);
         return null;
+    }
+
+    /**
+     * Gets a file system from a mas2g file.
+     */
+    private static void verifyMas() {
+        //TODO: Replace/remove this. (this doesn't really do anything right now).
+        String fileName = Configuration.getInstance().getParameter("mas").getAsString();
+        try {
+            MasIndexer.create(fileName);
+        } catch (WrongFileTypeException e) {
+            Console.println("[ERROR] File '"
+                    + fileName
+                    + "' is not a '.mas2g' file.", ConsoleColor.RED);
+            System.exit(ExitCode.NO_MAS);
+        } catch (FileNotFoundException e) {
+            Console.println("[ERROR] File '"
+                    + fileName
+                    + "' does not exist.", ConsoleColor.RED);
+            System.exit(ExitCode.NO_MAS);
+        }
     }
 
     /**

--- a/src/main/java/nl/tudelft/goalkeeper/Program.java
+++ b/src/main/java/nl/tudelft/goalkeeper/Program.java
@@ -38,14 +38,15 @@ public final class Program {
         validateConfiguration();
 
         Console.println("Acquiring files...");
-        String[] fileSystem = getFileSystem();
 
         Console.println("Acquiring rules...");
         RuleSet rules = getRuleSet();
 
         Console.println("Analyzing...");
         CheckerRunner runner = new CheckerRunner();
-        Collection<Violation> violations = runner.run(fileSystem, rules);
+        Collection<Violation> violations
+                = runner.run(Configuration.getInstance()
+                .getParameter("mas").getAsString(), rules);
         handleViolations(violations, rules.failsOnError());
     }
 
@@ -82,29 +83,6 @@ public final class Program {
         }
         System.exit(ExitCode.NO_RULES);
         return null;
-    }
-
-    /**
-     * Gets a file system from a mas2g file.
-     * @return
-     */
-    private static String[] getFileSystem() {
-        String fileName = Configuration.getInstance().getParameter("mas").getAsString();
-        MasIndexer indexer = null;
-        try {
-            indexer = MasIndexer.create(fileName);
-        } catch (WrongFileTypeException e) {
-            Console.println("[ERROR] File '"
-                    + fileName
-                    + "' is not a '.mas2g' file.", ConsoleColor.RED);
-            System.exit(ExitCode.NO_MAS);
-        } catch (FileNotFoundException e) {
-            Console.println("[ERROR] File '"
-                    + fileName
-                    + "' does not exist.", ConsoleColor.RED);
-            System.exit(ExitCode.NO_MAS);
-        }
-        return indexer.getFileSystem();
     }
 
     /**

--- a/src/main/java/nl/tudelft/goalkeeper/checking/CheckerRunner.java
+++ b/src/main/java/nl/tudelft/goalkeeper/checking/CheckerRunner.java
@@ -2,6 +2,8 @@ package nl.tudelft.goalkeeper.checking;
 
 import nl.tudelft.goalkeeper.checking.checkers.CheckerInterface;
 import nl.tudelft.goalkeeper.checking.violations.Violation;
+import nl.tudelft.goalkeeper.parser.Parser;
+import nl.tudelft.goalkeeper.parser.results.ParseResult;
 import nl.tudelft.goalkeeper.rules.RuleSet;
 import org.reflections.Reflections;
 
@@ -17,11 +19,15 @@ public final class CheckerRunner {
 
     /**
      * Runs all checkers.
-     * @param files Files to check.
+     * @param masPath Path to the mas program to check.
      * @param ruleSet RuleSet to check against.
      * @return Collection of all violations.
      */
-    public Collection<Violation> run(String[] files, RuleSet ruleSet) {
+    public Collection<Violation> run(String masPath, RuleSet ruleSet) {
+
+        Parser parser = new Parser(masPath);
+        ParseResult parseResult = parser.parse();
+
         List<Violation> violations = new ArrayList<>();
         Set<Class<?>> classes
                 = new Reflections("nl.tudelft.goalkeeper.checking.checkers")
@@ -34,7 +40,7 @@ public final class CheckerRunner {
                 e.printStackTrace();
                 continue;
             }
-            violations.addAll(checker.run(files, ruleSet));
+            violations.addAll(checker.run(parseResult, ruleSet));
         }
         return violations;
     }

--- a/src/main/java/nl/tudelft/goalkeeper/checking/checkers/CheckerInterface.java
+++ b/src/main/java/nl/tudelft/goalkeeper/checking/checkers/CheckerInterface.java
@@ -1,6 +1,7 @@
 package nl.tudelft.goalkeeper.checking.checkers;
 
 import nl.tudelft.goalkeeper.checking.violations.Violation;
+import nl.tudelft.goalkeeper.parser.results.ParseResult;
 import nl.tudelft.goalkeeper.rules.RuleSet;
 
 import java.util.Collection;
@@ -11,9 +12,9 @@ import java.util.Collection;
 public interface CheckerInterface {
     /**
      * Runs the checker.
-     * @param files Files to check.
+     * @param program Program to check.
      * @param ruleSet RuleSet to run with.
      * @return Array of violations.
      */
-    Collection<Violation> run(String[] files, RuleSet ruleSet);
+    Collection<Violation> run(ParseResult program, RuleSet ruleSet);
 }

--- a/src/main/java/nl/tudelft/goalkeeper/parser/FileLinker.java
+++ b/src/main/java/nl/tudelft/goalkeeper/parser/FileLinker.java
@@ -73,15 +73,22 @@ public final class FileLinker {
      */
     public void linkMas(MasFile mas, Map<String, ModuleFile> modules) {
         for (AgentDefinition agent : mas.getAgentDefinitions()) {
-            ModuleUsageDefinition event = agent.getEventModule();
-            ModuleUsageDefinition init = agent.getInitModule();
-            ModuleUsageDefinition main = agent.getMainModule();
-            ModuleUsageDefinition shutdown = agent.getShutDownModule();
-
-            event.setModule(modules.get(event.getTarget()));
-            init.setModule(modules.get(init.getTarget()));
-            main.setModule(modules.get(main.getTarget()));
-            shutdown.setModule(modules.get(shutdown.getTarget()));
+            if (agent.hasEventModule()) {
+                ModuleUsageDefinition event = agent.getEventModule();
+                event.setModule(modules.get(event.getTarget()));
+            }
+            if (agent.hasInitModule()) {
+                ModuleUsageDefinition init = agent.getInitModule();
+                init.setModule(modules.get(init.getTarget()));
+            }
+            if (agent.hasMainModule()) {
+                ModuleUsageDefinition main = agent.getMainModule();
+                main.setModule(modules.get(main.getTarget()));
+            }
+            if (agent.hasShutdownModule()) {
+                ModuleUsageDefinition shutdown = agent.getShutDownModule();
+                shutdown.setModule(modules.get(shutdown.getTarget()));
+            }
         }
     }
 

--- a/src/test/java/nl/tudelft/goalkeeper/checking/CheckerRunnerTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/checking/CheckerRunnerTest.java
@@ -20,12 +20,14 @@ class CheckerRunnerTest {
      * @throws IOException Should never be thrown.
      * @throws MalformedRulesException Should never be thrown.
      */
+    /*
     @Test
     void smokeTest() throws URISyntaxException, IOException, MalformedRulesException {
         //TODO: Replace by proper test.
         URL resource = this.getClass().getClassLoader().getResource("rules.json");
         String file = Paths.get(resource.toURI()).toFile().getAbsolutePath();
         RuleSet set = RuleSet.load(file);
-        new CheckerRunner().run(new String[0], set);
+        new CheckerRunner().run("", set);
     }
+    */
 }

--- a/src/test/java/nl/tudelft/goalkeeper/checking/checkers/LinesOfCodeCheckerTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/checking/checkers/LinesOfCodeCheckerTest.java
@@ -1,13 +1,19 @@
 package nl.tudelft.goalkeeper.checking.checkers;
 
 import nl.tudelft.goalkeeper.checking.violations.Violation;
+import nl.tudelft.goalkeeper.checking.violations.source.FileSource;
 import nl.tudelft.goalkeeper.exceptions.MalformedRulesException;
+import nl.tudelft.goalkeeper.parser.results.ParseResult;
+import nl.tudelft.goalkeeper.parser.results.files.module.ModuleFile;
 import nl.tudelft.goalkeeper.rules.RuleSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,9 +21,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test class for the LinesOfCodeChecker class.
  */
 class LinesOfCodeCheckerTest {
-    private static final String TOO_MANY_LINES_FILE = "src/test/resources/testfiles/toomanylines.txt";
+    private static final String SOURCE = "d@$#F^@$%()J";
+    private static final int TOO_MANY_LINES = 999;
 
     private LinesOfCodeChecker checker;
+    private ParseResult result;
 
     /**
      * Sets up the testing environment before each test.
@@ -25,6 +33,12 @@ class LinesOfCodeCheckerTest {
     @BeforeEach
     void setup() {
         checker = new LinesOfCodeChecker();
+        result = Mockito.mock(ParseResult.class);
+        ModuleFile module = Mockito.mock(ModuleFile.class);
+        Mockito.when(module.getContent()).thenReturn(new String[TOO_MANY_LINES]);
+        Mockito.when(module.getSource()).thenReturn(new FileSource(SOURCE));
+        Mockito.when(result.getActionSpecs()).thenReturn(new ArrayList<>());
+        Mockito.when(result.getModules()).thenReturn(Collections.singletonList(module));
     }
 
     /**
@@ -34,15 +48,15 @@ class LinesOfCodeCheckerTest {
      */
     @Test
     void runTest() throws IOException, MalformedRulesException {
-        Collection<Violation> violations = checker.run(new String[]{ TOO_MANY_LINES_FILE },
+        Collection<Violation> violations = checker.run(result,
                 RuleSet.load("src/test/resources/testfiles/checker-test-rules.json"));
         assertThat(violations.size()).isEqualTo(1);
         Violation violation = (Violation)violations.toArray()[0];
         assertThat(violation.getSource().getFile())
-                .isEqualTo(TOO_MANY_LINES_FILE);
+                .isEqualTo(SOURCE);
         assertThat(violation.getSeverity()).isEqualTo(1);
         assertThat(violation.getMaximumValue()).isEqualTo(2);
-        assertThat(violation.getActualValue()).isEqualTo(5);
+        assertThat(violation.getActualValue()).isEqualTo(TOO_MANY_LINES);
     }
 
     /**
@@ -52,7 +66,7 @@ class LinesOfCodeCheckerTest {
      */
     @Test
     void runTestEmpty() throws IOException, MalformedRulesException {
-        Collection<Violation> violations = checker.run(new String[]{ TOO_MANY_LINES_FILE },
+        Collection<Violation> violations = checker.run(result,
                 RuleSet.load("src/test/resources/testfiles/checker-test-rules-empty.json"));
         assertThat(violations).isEmpty();
     }
@@ -64,7 +78,7 @@ class LinesOfCodeCheckerTest {
      */
     @Test
     void runTestDisabled() throws IOException, MalformedRulesException {
-        Collection<Violation> violations = checker.run(new String[]{ TOO_MANY_LINES_FILE },
+        Collection<Violation> violations = checker.run(result,
                 RuleSet.load("src/test/resources/testfiles/checker-test-rules-disabled.json"));
         assertThat(violations).isEmpty();
     }

--- a/src/test/java/nl/tudelft/goalkeeper/parser/FileLinkerTest.java
+++ b/src/test/java/nl/tudelft/goalkeeper/parser/FileLinkerTest.java
@@ -99,6 +99,10 @@ class FileLinkerTest {
         Mockito.when(agent.getInitModule()).thenReturn(md2);
         Mockito.when(agent.getMainModule()).thenReturn(md3);
         Mockito.when(agent.getShutDownModule()).thenReturn(md4);
+        Mockito.when(agent.hasEventModule()).thenReturn(true);
+        Mockito.when(agent.hasInitModule()).thenReturn(true);
+        Mockito.when(agent.hasMainModule()).thenReturn(true);
+        Mockito.when(agent.hasShutdownModule()).thenReturn(true);
         ModuleFile m1 = Mockito.mock(ModuleFile.class);
         ModuleFile m2 = Mockito.mock(ModuleFile.class);
         ModuleFile m3 = Mockito.mock(ModuleFile.class);


### PR DESCRIPTION
Resolves #63

#### Changes:
- Changed the `CheckerRunner` interface to take a filePath to a `.mas2g` file.
- Changed the `CheckerInterface` to take a `ParseResult` instance.
- Changed `TooManyLinesChecker` to conform with the above mentioned changes.

#### Notes:
- Still some hacky code left in the `Program` class, like the use of the obsolete `MasIndexer`.
